### PR TITLE
show regex trigger in the completion list

### DIFF
--- a/src/completion.ts
+++ b/src/completion.ts
@@ -145,6 +145,7 @@ export function getCompletions(
         snippetMatches = true;
         matchGroups = match;
         label = match[0];
+        prefixMatches = true;
       }
     }
 


### PR DESCRIPTION
if you have a regex trigger it does not show in the completion list, the prefixMatches variable was not set on a regex match